### PR TITLE
Redis host configuration fix

### DIFF
--- a/src/main/java/io/suryawirawan/henry/beam/redis/io/CustomRedisIO.java
+++ b/src/main/java/io/suryawirawan/henry/beam/redis/io/CustomRedisIO.java
@@ -101,8 +101,7 @@ public class CustomRedisIO {
       checkArgument(host != null, "host can not be null");
       checkArgument(port > 0, "port can not be negative or 0");
       return builder()
-          .setConnectionConfiguration(connectionConfiguration().withHost(host))
-          .setConnectionConfiguration(connectionConfiguration().withPort(port))
+          .setConnectionConfiguration(connectionConfiguration().withHost(host).withPort(port))
           .build();
     }
 


### PR DESCRIPTION
Fixed an issue where Redis would always default to localhost despite setting it to a different host.